### PR TITLE
Fix: notes saving issues.

### DIFF
--- a/backend/jupyter-middleware/dharpa/vre/dev/notes/mock.py
+++ b/backend/jupyter-middleware/dharpa/vre/dev/notes/mock.py
@@ -27,7 +27,7 @@ class MockNotesStore:
     def add_note(self, step_id: str, note: Note):
         notes = self.notes[step_id]
         notes.append(Note(content=note.content, id=generate_id(),
-                          created_at=datetime.now()))
+                          created_at=datetime.now().isoformat()))
         self.notes[step_id] = notes
 
     def update_note(self, step_id: str, note: Note):

--- a/backend/jupyter-middleware/dharpa/vre/types/generated.py
+++ b/backend/jupyter-middleware/dharpa/vre/types/generated.py
@@ -2,7 +2,6 @@
 from dataclasses import dataclass
 from typing import Optional, List, Any, Dict, Union
 from enum import Enum
-from datetime import datetime
 
 
 @dataclass
@@ -364,8 +363,8 @@ class Note:
     """Represents a step note."""
     """Textual content of the note."""
     content: str
-    """When the note was created"""
-    created_at: datetime
+    """When the note was created. Must be an ISO string."""
+    created_at: str
     """Unique ID of the note."""
     id: str
     """Optional title of the note"""

--- a/packages/client-core/src/common/types/generated.ts
+++ b/packages/client-core/src/common/types/generated.ts
@@ -489,9 +489,9 @@ export interface Note {
    */
   content: string
   /**
-   * When the note was created
+   * When the note was created. Must be an ISO string.
    */
-  createdAt: Date
+  createdAt: string
   /**
    * Unique ID of the note.
    */

--- a/packages/client-core/src/common/types/kiaraGenerated.ts
+++ b/packages/client-core/src/common/types/kiaraGenerated.ts
@@ -109,9 +109,17 @@ export type ValueSchema1 = ValueSchema
  */
 export type IsConstant3 = boolean
 /**
+ * The metadata of the value itself (not the actual data).
+ */
+export type ValueMetadata = ValueMetadata1
+/**
  * Description of how/where the value was set.
  */
 export type Origin = string
+/**
+ * Aliases for this value.
+ */
+export type Aliases = string[]
 /**
  * The time the last update to this value happened.
  */
@@ -285,7 +293,7 @@ export interface PipelineInputField {
  * The schema contains the [ValueType][kiara.data.values.ValueType] of a value, as well as an optional default that
  * will be used if no user input was given (yet) for a value.
  *
- * For more complex container types like arrays, tables, unions etc, types can also be configured with values from the ``type_config`` field.
+ * For more complex container types like array, tables, unions etc, types can also be configured with values from the ``type_config`` field.
  */
 export interface ValueSchema {
   type: Type
@@ -341,11 +349,16 @@ export interface PipelineValue {
   isSet: IsSet
   valueSchema: ValueSchema1
   isConstant?: IsConstant3
-  origin?: Origin
+  valueMetadata: ValueMetadata
+  aliases: Aliases
   lastUpdate?: LastUpdate
   valueHash: ValueHash
   isStreaming?: IsStreaming
   metadata?: Metadata
+}
+export interface ValueMetadata1 {
+  origin?: Origin
+  [k: string]: unknown
 }
 /**
  * Metadata relating to the actual data (size, no. of rows, etc. -- depending on data type).

--- a/packages/client-core/src/hooks/useStepNotes.ts
+++ b/packages/client-core/src/hooks/useStepNotes.ts
@@ -2,16 +2,6 @@ import { useContext, useEffect, useState } from 'react'
 import { BackEndContext, handlerAdapter, Target } from '../common/context'
 import { Messages, Note } from '../common/types'
 
-const deserializeNote = (note: Note): Note => {
-  if (typeof note?.createdAt === 'string') note.createdAt = new Date(note.createdAt)
-  return note
-}
-const serializeNote = (note: Note): Note => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if (typeof note?.createdAt !== 'string') (note as any).createdAt = note?.createdAt?.toUTCString()
-  return note
-}
-
 type NewNote = Omit<Note, 'id' | 'createdAt'>
 
 export interface StepNoteHookResult {
@@ -35,7 +25,7 @@ export function useStepNotes(stepId: string): StepNoteHookResult {
 
     const handler = handlerAdapter(Messages.Notes.codec.Notes.decode, content => {
       if (content.stepId === stepId) {
-        setNotes(content.notes?.map(deserializeNote))
+        setNotes(content.notes)
       }
     })
     context.subscribe(Target.Notes, handler)
@@ -49,7 +39,7 @@ export function useStepNotes(stepId: string): StepNoteHookResult {
     context.sendMessage(
       Target.Notes,
       Messages.Notes.codec.Add.encode({
-        note: serializeNote({ ...note, id: '', createdAt: new Date() }),
+        note: { ...note, id: '', createdAt: new Date().toISOString() },
         stepId
       })
     )
@@ -74,7 +64,7 @@ export function useStepNotes(stepId: string): StepNoteHookResult {
       Target.Notes,
       Messages.Notes.codec.Update.encode({
         stepId,
-        note: serializeNote(note)
+        note
       })
     )
   }

--- a/packages/client-ui/src/components/pages/PlaygroundPage.tsx
+++ b/packages/client-ui/src/components/pages/PlaygroundPage.tsx
@@ -8,13 +8,13 @@ const PlaygroundPage = (): JSX.Element => {
       id: 'test1',
       content:
         '## boom Lorem \n**ipsum** dolor sit amet, consectetur adipiscing elit. Nulla eget nibh eget lorem porta venenatis ut vel massa. Aenean volutpat ex ac ex vehicula, pulvinar posuere elit elementum. Aenean in ante vel nulla finibus luctus non id eros. Fusce auctor tincidunt sem in vulputate. Sed finibus sollicitudin quam at bibendum. In eget ante id ligula pharetra egestas at quis lacus. Suspendisse potenti. Duis lacus enim, sagittis a consequat eget, tempus ut ante.',
-      createdAt: new Date()
+      createdAt: new Date().toISOString()
     },
     {
       id: 'test2',
       content:
         'lorem ipsum [Lorem ipsum](https://www.dharpa.org) dolor sit amet, consectetur adipiscing elit. Nulla eget nibh eget lorem porta venenatis ut vel massa. Aenean volutpat ex ac ex vehicula, pulvinar posuere elit elementum. Aenean in ante vel nulla finibus luctus non id eros. Fusce auctor tincidunt sem in vulputate. Sed finibus sollicitudin quam at bibendum. In eget ante id ligula pharetra egestas at quis lacus. Suspendisse potenti. Duis lacus enim, sagittis a consequat eget, tempus ut ante.',
-      createdAt: new Date(),
+      createdAt: new Date().toISOString(),
       title: 'Note number two'
     }
   ]

--- a/packages/notes-components/src/components/NoteItem.tsx
+++ b/packages/notes-components/src/components/NoteItem.tsx
@@ -33,7 +33,7 @@ export const NoteItem = ({ note, onClick }: NoteItemProps): JSX.Element => {
           <ListItemText disableTypography primary={<MarkdownRender content={note.content} />} />
         </Box>
         <Typography variant="caption" className={classes.timestamp} color="textSecondary">
-          {asTimeAgo(note.createdAt)}
+          {asTimeAgo(new Date(note.createdAt))}
         </Typography>
       </Box>
     </ListItem>

--- a/packages/notes-components/src/components/NoteViewerEditor.tsx
+++ b/packages/notes-components/src/components/NoteViewerEditor.tsx
@@ -71,7 +71,7 @@ export const NoteViewerEditor = ({
       <Grid item>
         {(note as Note)?.createdAt != null ? (
           <Typography variant="caption" color="textSecondary">
-            {asTimeAgo((note as Note).createdAt)}
+            {asTimeAgo(new Date((note as Note).createdAt))}
           </Typography>
         ) : (
           ''

--- a/schema/json/types/notes/Note.json
+++ b/schema/json/types/notes/Note.json
@@ -19,8 +19,7 @@
     },
     "createdAt": {
       "type": "string",
-      "format": "date-time",
-      "description": "When the note was created"
+      "description": "When the note was created. Must be an ISO string."
     }
   },
   "required": [


### PR DESCRIPTION
Using iso formatted string for timestamps for better Python/JS compatibility.

For developers who use `standalone` version:  remove the `__dharpa_workflows_notes` local storage entry.