### PR TITLE
Fixed default data repo fields and loading of mock processor

### DIFF
--- a/packages/modules/src/dataSelection/index.tsx
+++ b/packages/modules/src/dataSelection/index.tsx
@@ -77,7 +77,9 @@ const mockProcessor = (
 ): OutputValues => {
   if (dataRepositoryTable == null) return
 
-  const fields = new Set(((metadataFields ?? []) as KnownMetadataFields[]).concat(['id']))
+  const fields = new Set(
+    ((metadataFields ?? []) as KnownMetadataFields[]).concat(['id', 'alias', 'columnNames'])
+  )
 
   const selectedItems = arrowUtils.filterTable(dataRepositoryTable.select(...fields), row =>
     selectedItemsIds.includes(row.id)


### PR DESCRIPTION
* hardcoded default data repository metadata fields passed over to data mapping step.
* wait for lazy loaded components to load and then access mock processor function.