### PR TITLE
Expose step ID in the URL

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -3,7 +3,7 @@ name: Type check and lint code
 on: [push]
 
 jobs:
-  build:
+  typecheck_and_lint:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/applications/standalone/src/mock/resources/sampleKiaraWorkflowState.yml
+++ b/applications/standalone/src/mock/resources/sampleKiaraWorkflowState.yml
@@ -1112,9 +1112,7 @@ structure:
         typeConfig: {}
   processingStages:
   - - m1
-    - m4
   - - m2
-    - m5
   - - m3
   steps:
     m1:

--- a/packages/client-core/src/common/utils/workflow.ts
+++ b/packages/client-core/src/common/utils/workflow.ts
@@ -1,4 +1,4 @@
-import { PipelineState, StepDesc } from '../types'
+import { PipelineState, StepDesc, PipelineStructure } from '../types'
 
 const PipelineTag = '__pipeline__'
 
@@ -32,4 +32,13 @@ export function getStepsConnections(
   inputId: string
 ): [string, string][] {
   return connections?.[inputId]?.filter(onlyStepConnections).map(parseStepConnectionString)
+}
+
+/**
+ * Workflow steps may be defined out of order in the workflow structure but they
+ * have a certain execution order. This helper returns steps IDs in the correct
+ * order of execution.
+ */
+export function getOrderedStepIds(pipelineStructure: PipelineStructure): string[] {
+  return pipelineStructure?.processingStages?.flat() ?? []
 }

--- a/packages/client-ui/src/components/App.tsx
+++ b/packages/client-ui/src/components/App.tsx
@@ -16,6 +16,8 @@ import LabPage from './pages/LabPage'
 import PlaygroundPage from './pages/PlaygroundPage'
 import WorkflowProjectPage from './pages/WorkflowProjectPage'
 
+const WorkflowUrlPrefix = '/workflows/network-analysis/directed'
+
 export const App = (): JSX.Element => {
   return (
     <ThemeContextProvider>
@@ -27,7 +29,11 @@ export const App = (): JSX.Element => {
                 <Redirect from="/" exact to="/home" />
                 <Route path="/home" exact component={HomePage} />
                 <Route path="/workflows/network-analysis" exact component={NetworkAnalysisPage} />
-                <Route path="/workflows/network-analysis/directed" exact component={WorkflowProjectPage} />
+                <Route
+                  path={`${WorkflowUrlPrefix}/:stepId?`}
+                  exact
+                  component={() => <WorkflowProjectPage pageUrlPrefix={WorkflowUrlPrefix} />}
+                />
                 {/* <Route path="/intro" exact component={IntroPage} /> */}
                 {/* <Route path="/projects/:id" exact component={ProjectPage} /> */}
                 <Route path="/toy" exact component={ToyVrePage} />

--- a/packages/client-ui/src/components/pages/WorkflowProjectPage.tsx
+++ b/packages/client-ui/src/components/pages/WorkflowProjectPage.tsx
@@ -1,21 +1,50 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
+import { useParams } from 'react-router'
+import { useHistory } from 'react-router-dom'
 
 import Button from '@material-ui/core/Button'
 
 import WorkflowContextProvider from '../../context/workflowContext'
 
 import WorkflowContainer from '../common/WorkflowContainer'
+import { WorkflowStepSynchroniser } from '../renderless/WorkflowStepSynchroniser'
 
 import useStyles from './WorkflowProjectPage.styles'
 
-const WorkflowProjectPage = (): JSX.Element => {
-  const classes = useStyles()
+interface RouterParams {
+  stepId?: string
+}
+const stepParameterName: keyof RouterParams = 'stepId'
 
-  const [dataSource, setDataSource] = useState<string>(null)
+export interface WorkflowProjectPageProps {
+  /**
+   * URL prefix of this page without the step ID suffix.
+   */
+  pageUrlPrefix: string
+}
+
+const WorkflowProjectPage = ({ pageUrlPrefix }: WorkflowProjectPageProps): JSX.Element => {
+  const classes = useStyles()
+  const { stepId } = useParams<RouterParams>()
+  const history = useHistory()
+
+  const [dataSource, setDataSource] = useState<'repository' | 'upload'>(null)
+
+  useEffect(() => {
+    if (stepId != null && dataSource == null) setDataSource('repository')
+  }, [stepId])
+
+  const handleWorkflowStepUpdated = (stepId: string) => {
+    history.push(`${pageUrlPrefix}/${stepId}`)
+  }
 
   if (dataSource === 'repository')
     return (
       <WorkflowContextProvider>
+        <WorkflowStepSynchroniser
+          stepParameterName={stepParameterName}
+          onStepUpdated={handleWorkflowStepUpdated}
+        />
         <WorkflowContainer />
       </WorkflowContextProvider>
     )

--- a/packages/client-ui/src/components/renderless/WorkflowStepSynchroniser.tsx
+++ b/packages/client-ui/src/components/renderless/WorkflowStepSynchroniser.tsx
@@ -1,0 +1,53 @@
+import React, { useContext, useEffect } from 'react'
+import { useParams } from 'react-router'
+import { useCurrentWorkflow, workflowUtils } from '@dharpa-vre/client-core'
+import { WorkflowContext } from '../../context/workflowContext'
+
+interface WorkflowStepSynchroniserProps {
+  stepParameterName: string
+  onStepUpdated: (stepId: string) => void
+}
+
+/**
+ * Synchronise workflow steps between the workflow context and
+ * the URL.
+ */
+export const WorkflowStepSynchroniser = ({
+  stepParameterName,
+  onStepUpdated
+}: WorkflowStepSynchroniserProps): JSX.Element => {
+  const { activeStep, setActiveStep } = useContext(WorkflowContext)
+  const params = useParams<{ [key: string]: string }>()
+  const stepId = params[stepParameterName]
+
+  const [currentWorkflow] = useCurrentWorkflow()
+
+  useEffect(() => {
+    if (currentWorkflow == null) return
+    // when the page is created, the source of truth is parameters.
+    const stepIds = workflowUtils.getOrderedStepIds(currentWorkflow)
+    const stepIndex = stepIds.indexOf(stepId)
+    if (stepIndex >= 0) setActiveStep([stepIndex, 0])
+    else setActiveStep([0, 0])
+  }, [currentWorkflow])
+
+  useEffect(() => {
+    if (currentWorkflow == null) return
+
+    const stepIds = workflowUtils.getOrderedStepIds(currentWorkflow)
+    const stepIndex = stepIds.indexOf(stepId)
+    if (stepIndex != activeStep) setActiveStep([stepIndex, 0])
+  }, [stepId])
+
+  useEffect(() => {
+    if (currentWorkflow == null) return
+
+    const stepIds = workflowUtils.getOrderedStepIds(currentWorkflow)
+    const stepIndex = stepIds.indexOf(stepId)
+    if (stepIndex != activeStep) {
+      onStepUpdated(stepIds[activeStep])
+    }
+  }, [activeStep])
+
+  return <></>
+}

--- a/packages/client-ui/src/context/workflowContext.tsx
+++ b/packages/client-ui/src/context/workflowContext.tsx
@@ -1,6 +1,6 @@
 import React, { useState, createContext, Dispatch, SetStateAction } from 'react'
 
-import { useCurrentWorkflow } from '@dharpa-vre/client-core'
+import { useCurrentWorkflow, workflowUtils } from '@dharpa-vre/client-core'
 import { StepDesc } from '@dharpa-vre/client-core/src/common/types/kiaraGenerated'
 
 export type WorkflowType = {
@@ -40,8 +40,9 @@ const WorkflowContextProvider = ({ children }: WorkflowProviderProps): JSX.Eleme
   const [mainPaneHeight, setMainPaneHeight] = useState<number>(0)
   const [mainPaneWidth, setMainPaneWidth] = useState<number>(0)
 
-  const projectSteps: StepDesc[] = Object.values(currentWorkflow?.steps || {}) || []
-  const idCurrentStep = projectSteps?.[activeStep]?.step?.stepId
+  const stepIds = workflowUtils.getOrderedStepIds(currentWorkflow)
+  const idCurrentStep = stepIds[activeStep]
+  const projectSteps: StepDesc[] = stepIds.map(stepId => currentWorkflow?.steps?.[stepId])
 
   return (
     <WorkflowContext.Provider


### PR DESCRIPTION
Keep the current step ID in the URL so that we stay on the same page after page reload. Addresses https://github.com/DHARPA-Project/lumy/issues/70