### PR TITLE
Using data transformers and updated network analysis datavis page

### DIFF
--- a/applications/jupyter-app/package.json
+++ b/applications/jupyter-app/package.json
@@ -73,7 +73,7 @@
   ],
   "lumy": {
     "middleware": {
-      "version": "0.3.6"
+      "version": "0.3.7"
     }
   }
 }

--- a/applications/jupyter-app/package.json
+++ b/applications/jupyter-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dharpa-vre/jupyter-app",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "DHARPA VRE as a Jupyter app.",
   "keywords": [
     "jupyter"

--- a/packages/client-core/src/common/types/generated.ts
+++ b/packages/client-core/src/common/types/generated.ts
@@ -776,8 +776,45 @@ export interface LumyWorkflowMetadata {
  * Workflow processing configuration details
  */
 export interface ProcessingSection {
+  data?: DataProcessingDetailsSection
   dependencies?: ProcessingDependenciesSection
   workflow: ProcessingWorkflowSection
+}
+
+export interface DataProcessingDetailsSection {
+  transformations?: DataTransformationDescriptor[]
+}
+
+/**
+ * Data type transformation method details.
+ */
+export interface DataTransformationDescriptor {
+  /**
+   * If set to 'true', this transformation will be used for this particular type by default if
+   * more than one transformation is available and no view is provided.
+   */
+  default?: boolean
+  pipeline: DataTransformationItemPipelineDetails
+  /**
+   * Name of source Kiara data type to apply transformation to.
+   */
+  sourceType: string
+  /**
+   * Name of target Kiara data type to apply transformation to.
+   */
+  targetType: string
+  /**
+   * Name of the view which serves as an additional hint which transformation to choose if
+   * there is more than one available
+   */
+  view?: string
+}
+
+export interface DataTransformationItemPipelineDetails {
+  /**
+   * Name of the Kiara pipeline to use.
+   */
+  name: string
 }
 
 export interface ProcessingDependenciesSection {
@@ -905,6 +942,15 @@ export interface WorkflowPageMapping {
    * ID of the input/output on the page
    */
   pageIoId: string
+  /**
+   * Specifies type the input is expected to be in.
+   * A respective data transformation method will be used.
+   */
+  type?: string
+  /**
+   * Name of the view transformation to use for the expected type.
+   */
+  view?: string
   /**
    * ID of the input/output on the processing side
    */

--- a/packages/datavis-components/src/components/network-force.ts
+++ b/packages/datavis-components/src/components/network-force.ts
@@ -9,7 +9,7 @@ export interface NodeMetadata {
   group: string
   scaler?: number
   label: string
-  [key: string]: unknown
+  scalerActualValue?: number
 }
 
 export interface EdgeMetadata {

--- a/packages/modules/src/networkAnalysisDataMapping/index.tsx
+++ b/packages/modules/src/networkAnalysisDataMapping/index.tsx
@@ -28,7 +28,7 @@ const dataMappingTableCaption =
   'Map data sources to data sets required for this workflow. The first column lists the names of the (re)sources from which you can extract data. The headings of the other columns are the names of the data sets required for this workflow. The labels of the selection fields are the names of the required data fields. The options on the drop-down list correspond to columns found in your data (re)source.'
 
 const nodeFields = ['id', 'label', 'group']
-const edgeFields = ['srcId', 'tgtId', 'weight']
+const edgeFields = ['source', 'target', 'weight']
 
 const networkAnalysisDataSets: IRequiredDataSetProp[] = [
   {

--- a/packages/modules/src/networkAnalysisDataVis/components/NetworkAnalysisVisualization.tsx
+++ b/packages/modules/src/networkAnalysisDataVis/components/NetworkAnalysisVisualization.tsx
@@ -48,7 +48,7 @@ const NetworkAnalysisVisualizationContainer = (): JSX.Element => {
             }}
             label={graphTooltipInfo.nodeMetadata.label}
             scalingMethod={nodeScalingMethod}
-            scalingValue={graphTooltipInfo.nodeMetadata.scaler}
+            scalingValue={graphTooltipInfo.nodeMetadata.scalerActualValue}
             group={graphTooltipInfo.nodeMetadata.group}
           />
         )}

--- a/packages/modules/src/networkAnalysisDataVis/components/settings/subsettings/nodes/NodeSize.tsx
+++ b/packages/modules/src/networkAnalysisDataVis/components/settings/subsettings/nodes/NodeSize.tsx
@@ -7,7 +7,9 @@ import { NetworkGraphContext } from '../../../../context'
 const scalingMethodLabels: Record<ScalingMethod, string> = {
   degree: 'most connections to other nodes (hubs)',
   betweenness: 'bridges between groups of nodes (brokers)',
-  eigenvector: 'best connected to hubs'
+  eigenvector: 'best connected to hubs',
+  indegree: 'In degree',
+  outdegree: 'Out degree'
 }
 const scalingMethodValues: Option[] = [{ value: undefined, label: 'equal' }].concat(
   Object.entries(scalingMethodLabels).map(([value, label]) => ({ value, label }))

--- a/packages/modules/src/networkAnalysisDataVis/components/statistics/GraphStatsPanel.tsx
+++ b/packages/modules/src/networkAnalysisDataVis/components/statistics/GraphStatsPanel.tsx
@@ -12,11 +12,11 @@ import Divider from '@material-ui/core/Divider'
 
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 
-import { OutputValues } from '../../structure'
+import { GraphStats } from '../../structure'
 import useStyles from './GraphStatsPanel.styles'
 
 export interface GraphStatsPanelProps {
-  graphStats: OutputValues['graphStats']
+  graphStats: Partial<GraphStats>
 }
 
 const TableCell = ({ children }: TableCellProps): JSX.Element => {
@@ -41,27 +41,27 @@ export const GraphStatsPanel = ({ graphStats }: GraphStatsPanelProps): JSX.Eleme
             <TableBody>
               <TableRow>
                 <TableCell>Number of nodes:</TableCell>
-                <TableCell>{graphStats?.nodesCount.toFixed(0)}</TableCell>
+                <TableCell>{graphStats?.nodesCount?.toFixed(0)}</TableCell>
               </TableRow>
               <TableRow>
                 <TableCell>Number of edges:</TableCell>
-                <TableCell>{graphStats?.edgesCount.toFixed(0)}</TableCell>
+                <TableCell>{graphStats?.edgesCount?.toFixed(0)}</TableCell>
               </TableRow>
               <TableRow>
                 <TableCell>Density:</TableCell>
-                <TableCell>{graphStats?.density.toFixed(2)}</TableCell>
+                <TableCell>{graphStats?.density?.toFixed(2)}</TableCell>
               </TableRow>
               <TableRow>
                 <TableCell>Avg. in degree:</TableCell>
-                <TableCell>{graphStats?.averageInDegree.toFixed(2)}</TableCell>
+                <TableCell>{graphStats?.averageInDegree?.toFixed(2)}</TableCell>
               </TableRow>
               <TableRow>
                 <TableCell>Avg. out degree:</TableCell>
-                <TableCell>{graphStats?.averageOutDegree.toFixed(2)}</TableCell>
+                <TableCell>{graphStats?.averageOutDegree?.toFixed(2)}</TableCell>
               </TableRow>
               <TableRow>
                 <TableCell>Avg. shortest path length:</TableCell>
-                <TableCell>{graphStats?.averageShortestPathLength.toFixed(2)}</TableCell>
+                <TableCell>{graphStats?.averageShortestPathLength?.toFixed(2)}</TableCell>
               </TableRow>
             </TableBody>
           </Table>

--- a/packages/modules/src/networkAnalysisDataVis/graphDataMethods.ts
+++ b/packages/modules/src/networkAnalysisDataVis/graphDataMethods.ts
@@ -37,8 +37,8 @@ export function buildGraphNodes(
 export function buildGraphEdges(edges: InputValues['edges']): EdgeMetadata[] | undefined {
   if (edges == null) return undefined
   return [...edges.toArray()].map(edge => ({
-    sourceId: String(edge.srcId),
-    targetId: String(edge.tgtId)
+    sourceId: String(edge.source),
+    targetId: String(edge.target)
   }))
 }
 

--- a/packages/modules/src/networkAnalysisDataVis/mockProcessor.ts
+++ b/packages/modules/src/networkAnalysisDataVis/mockProcessor.ts
@@ -62,7 +62,7 @@ const generateNodesAndEdges = () => {
       Utf8Vector.from(cnums.map(() => getRandomNodeId())),
       Int32Vector.from(cnums.map(() => getRandomWeight()))
     ],
-    ['srcId', 'tgtId', 'weight']
+    ['source', 'target', 'weight']
   )
   return { nodes, edges }
 }
@@ -82,7 +82,7 @@ export const mockProcessor = ({
 
   const ids = [...nodes.getColumn('id')]
 
-  const notIsolatedNodesIds = new Set([...edges.getColumn('srcId')].concat([...edges.getColumn('tgtId')]))
+  const notIsolatedNodesIds = new Set([...edges.getColumn('source')].concat([...edges.getColumn('target')]))
   const isIsolated = [...nodes.getColumn('id')].map(id => !notIsolatedNodesIds.has(id))
 
   const graphData = Table.new<GraphDataStructure>(
@@ -103,8 +103,10 @@ export const mockProcessor = ({
   if (selectedNodeId != null) {
     const id = selectedNodeId.toString()
     directConnections = ([...edges]
-      .filter(row => row.srcId === id || row.tgtId === id)
-      .map(row => (row.srcId === id ? row.tgtId : row.srcId)) as unknown) as OutputValues['directConnections']
+      .filter(row => row.source === id || row.target === id)
+      .map(row =>
+        row.source === id ? row.target : row.source
+      ) as unknown) as OutputValues['directConnections']
   }
 
   let shortestPath: OutputValues['shortestPath'] = []

--- a/packages/modules/src/networkAnalysisDataVis/mockProcessor.ts
+++ b/packages/modules/src/networkAnalysisDataVis/mockProcessor.ts
@@ -1,27 +1,35 @@
-import { Table, Bool, Float32Vector, Vector, BoolVector, Utf8Vector, Int32Vector } from 'apache-arrow'
+import { Table, Float32Vector, BoolVector, Utf8Vector, Int32Vector } from 'apache-arrow'
 import { MockProcessorResult } from '@dharpa-vre/client-core'
-import { EdgesStructure, GraphDataStructure, InputValues, NodesStructure, OutputValues } from './structure'
+import {
+  EdgesStructure,
+  CentralityMeasures,
+  InputValues,
+  OutputValues,
+  GraphStats,
+  FullNodesStructure
+} from './structure'
 
-type NodeValues = Record<keyof GraphDataStructure, unknown>
+type NodeCentralityMeasures = Record<keyof CentralityMeasures, unknown>
 
-const fakeNodesValues: { [nodeId: string]: NodeValues } = {}
+const fakeNodesValues: { [nodeId: string]: Omit<NodeCentralityMeasures, 'isolated'> } = {}
 
-const getNodeValues = (nodeId: string): NodeValues => {
+const getNodeValues = (nodeId: string): Omit<NodeCentralityMeasures, 'isolated'> => {
   if (fakeNodesValues[nodeId] == null) {
     fakeNodesValues[nodeId] = {
-      degree: Math.random(),
+      degree: Math.random() * 90,
       eigenvector: Math.random(),
       betweenness: Math.random(),
-      isLarge: Math.random() > 0.5 ? true : null,
-      isIsolated: false
+      indegree: Math.random() * 90,
+      outdegree: Math.random() * 90
     }
   }
   return fakeNodesValues[nodeId]
 }
 
-const fakeGraphStats: OutputValues['graphStats'] = {
+const fakeGraphStats: GraphStats = {
   nodesCount: Math.random() * 100,
   edgesCount: Math.random() * 100,
+  averageDegree: Math.random(),
   averageInDegree: Math.random(),
   averageOutDegree: Math.random(),
   density: Math.random(),
@@ -48,14 +56,8 @@ const generateNodesAndEdges = () => {
   const maxWeight = 30
   const getRandomWeight = () => Math.floor(Math.random() * maxWeight)
 
-  const nodes = Table.new<NodesStructure>(
-    [
-      Utf8Vector.from(nums.map(i => String(i))),
-      Utf8Vector.from(nums.map(i => `Node ${i}`)),
-      Utf8Vector.from(nums.map(() => getRandomGroup()))
-    ],
-    ['id', 'label', 'group']
-  )
+  const nodeIds = nums.map(String)
+
   const edges = Table.new<EdgesStructure>(
     [
       Utf8Vector.from(cnums.map(() => getRandomNodeId())),
@@ -64,40 +66,36 @@ const generateNodesAndEdges = () => {
     ],
     ['source', 'target', 'weight']
   )
+
+  const notIsolatedNodesIds = new Set([...edges.getColumn('source')].concat([...edges.getColumn('target')]))
+  const isIsolated = nodeIds.map(id => !notIsolatedNodesIds.has(id))
+
+  const nodes = Table.new<FullNodesStructure>(
+    [
+      Utf8Vector.from(nodeIds),
+      Utf8Vector.from(nodeIds.map(i => `Node ${i}`)),
+      Utf8Vector.from(nodeIds.map(() => getRandomGroup())),
+
+      Float32Vector.from(nodeIds.map(id => getNodeValues(id).degree)),
+      Float32Vector.from(nodeIds.map(id => getNodeValues(id).eigenvector)),
+      Float32Vector.from(nodeIds.map(id => getNodeValues(id).betweenness)),
+      Float32Vector.from(nodeIds.map(id => getNodeValues(id).indegree)),
+      Float32Vector.from(nodeIds.map(id => getNodeValues(id).outdegree)),
+      BoolVector.from(isIsolated)
+    ],
+    ['id', 'label', 'group', 'degree', 'eigenvector', 'betweenness', 'indegree', 'outdegree', 'isolated']
+  )
   return { nodes, edges }
 }
 
 export const mockProcessor = ({
-  nodes,
-  edges,
   selectedNodeId,
   shortestPathSource,
   shortestPathTarget
 }: InputValues): MockProcessorResult<InputValues, OutputValues> => {
-  if (nodes == null || edges == null) {
-    const generated = generateNodesAndEdges()
-    nodes = generated.nodes
-    edges = generated.edges
-  }
-
-  const ids = [...nodes.getColumn('id')]
-
-  const notIsolatedNodesIds = new Set([...edges.getColumn('source')].concat([...edges.getColumn('target')]))
-  const isIsolated = [...nodes.getColumn('id')].map(id => !notIsolatedNodesIds.has(id))
-
-  const graphData = Table.new<GraphDataStructure>(
-    [
-      Float32Vector.from(ids.map(id => getNodeValues(id).degree)),
-      Float32Vector.from(ids.map(id => getNodeValues(id).eigenvector)),
-      Float32Vector.from(ids.map(id => getNodeValues(id).betweenness)),
-      Vector.from({
-        values: ids.map(id => getNodeValues(id).isLarge),
-        type: new Bool()
-      }),
-      BoolVector.from(isIsolated)
-    ],
-    ['degree', 'eigenvector', 'betweenness', 'isLarge', 'isIsolated']
-  )
+  const generated = generateNodesAndEdges()
+  const nodes = generated.nodes
+  const edges = generated.edges
 
   let directConnections: OutputValues['directConnections'] = []
   if (selectedNodeId != null) {
@@ -115,15 +113,13 @@ export const mockProcessor = ({
   }
 
   return {
-    inputs: {
-      nodes,
-      edges
-    },
+    inputs: {},
     outputs: {
-      graphData,
+      nodes,
+      edges,
       shortestPath,
       directConnections,
-      graphStats: fakeGraphStats
+      ...fakeGraphStats
     }
   }
 }

--- a/packages/modules/src/networkAnalysisDataVis/structure.ts
+++ b/packages/modules/src/networkAnalysisDataVis/structure.ts
@@ -14,19 +14,20 @@ export type NodesStructure = {
   group: Utf8
 }
 
-export type GraphDataStructure = {
+export type CentralityMeasures = {
   degree: Float32
   eigenvector: Float32
   betweenness: Float32
-  isLarge: Bool
-  isIsolated: Bool
+  indegree: Float32
+  outdegree: Float32
+  isolated: Bool
 }
 
-export type ScalingMethod = keyof Omit<GraphDataStructure, 'isLarge' | 'isIsolated'>
+export type FullNodesStructure = NodesStructure & CentralityMeasures
 
-type GraphDataTable = Table<GraphDataStructure>
+export type ScalingMethod = keyof Omit<CentralityMeasures, 'isolated'>
 
-type NodesTable = Table<NodesStructure>
+type NodesTable = Table<FullNodesStructure>
 type EdgesTable = Table<EdgesStructure>
 
 enum ShortestPathMethod {
@@ -34,33 +35,34 @@ enum ShortestPathMethod {
   NotWeighted = 'notWeighted'
 }
 
-enum GraphType {
-  Directed = 'directed',
-  Undirected = 'undirected'
-}
+// enum GraphType {
+//   Directed = 'directed',
+//   Undirected = 'undirected'
+// }
 
-interface GraphStats {
+export interface GraphStats {
   nodesCount: number
   edgesCount: number
+  averageDegree: number
   averageInDegree: number
   averageOutDegree: number
   density: number
   averageShortestPathLength: number
+  // graphType: GraphType
 }
 
 export interface InputValues {
-  nodes: NodesTable
-  edges: EdgesTable
   shortestPathSource: NodeId
   shortestPathTarget: NodeId
   shortestPathMethod: ShortestPathMethod
-  graphType: GraphType
   selectedNodeId: NodeId
 }
 
-export interface OutputValues {
-  graphData: GraphDataTable
+interface BaseOutputValues {
+  nodes: NodesTable
+  edges: EdgesTable
   shortestPath: NodeId[]
   directConnections: NodeId[]
-  graphStats: GraphStats
 }
+
+export type OutputValues = BaseOutputValues & GraphStats

--- a/packages/modules/src/networkAnalysisDataVis/structure.ts
+++ b/packages/modules/src/networkAnalysisDataVis/structure.ts
@@ -3,8 +3,8 @@ import { Table, Int32, Utf8, Float32, Bool } from 'apache-arrow'
 type NodeId = string
 
 export type EdgesStructure = {
-  srcId: Utf8
-  tgtId: Utf8
+  source: Utf8
+  target: Utf8
   weight: Int32
 }
 

--- a/schema/json/types/workflow/LumyWorkflow.json
+++ b/schema/json/types/workflow/LumyWorkflow.json
@@ -189,7 +189,7 @@
           "properties": {
             "name": {
               "type": "string",
-              "description": "Name of the Kiara pipeline to use."
+              "description": "Name of the Kiara pipeline to use.\nThe pipeline must have one input: 'source' and one output: 'target'."
             }
           },
           "required": [

--- a/schema/json/types/workflow/LumyWorkflow.json
+++ b/schema/json/types/workflow/LumyWorkflow.json
@@ -153,11 +153,62 @@
         "pageIoId": {
           "type": "string",
           "description": "ID of the input/output on the page"
+        },
+        "type": {
+          "type": "string",
+          "description": "Specifies type the input is expected to be in.\nA respective data transformation method will be used."
+        },
+        "view": {
+          "type": "string",
+          "description": "Name of the view transformation to use for the expected type."
         }
       },
       "required": [
         "workflowIoId",
         "pageIoId"
+      ]
+    },
+    "dataTransformationItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "title": "DataTransformationDescriptor",
+      "description": "Data type transformation method details.",
+      "properties": {
+        "sourceType": {
+          "type": "string",
+          "description": "Name of source Kiara data type to apply transformation to."
+        },
+        "targetType": {
+          "type": "string",
+          "description": "Name of target Kiara data type to apply transformation to."
+        },
+        "pipeline": {
+          "type": "object",
+          "additionalProperties": false,
+          "title": "DataTransformationItemPipelineDetails",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of the Kiara pipeline to use."
+            }
+          },
+          "required": [
+            "name"
+          ]
+        },
+        "view": {
+          "type": "string",
+          "description": "Name of the view which serves as an additional hint which transformation to choose if there is more than one available"
+        },
+        "default": {
+          "type": "boolean",
+          "description": "If set to 'true', this transformation will be used for this particular type by default if more than one transformation is available and no view is provided."
+        }
+      },
+      "required": [
+        "sourceType",
+        "targetType",
+        "pipeline"
       ]
     }
   },
@@ -191,6 +242,19 @@
               "type": "array",
               "items": {
                 "$ref": "#/definitions/packageDependency"
+              }
+            }
+          }
+        },
+        "data": {
+          "type": "object",
+          "additionalProperties": false,
+          "title": "DataProcessingDetailsSection",
+          "properties": {
+            "transformations": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/dataTransformationItem"
               }
             }
           }


### PR DESCRIPTION
Data transformers are now used to transform graph to table in network analysis workflow.
Using more fine grained kiara modules for network graph analysis.
Updated datavis page code to use inputs/outputs from these new modules.