### PR TITLE
Render sandbox app in dedicated container

### DIFF
--- a/packages/module-sandbox/src/app/index.tsx
+++ b/packages/module-sandbox/src/app/index.tsx
@@ -3,5 +3,12 @@ import { render } from 'react-dom'
 import { App } from './App'
 
 export function sandbox(): void {
-  render(<App />, document.body)
+  let sandboxRootElement = document.getElementById('sandbox')
+
+  if (sandboxRootElement == null) {
+    sandboxRootElement = document.createElement('div')
+    sandboxRootElement.setAttribute('id', 'sandbox')
+    document.querySelector('body').appendChild(sandboxRootElement)
+  }
+  render(<App />, sandboxRootElement)
 }


### PR DESCRIPTION
React warns against rendering apps directly in the body of the document, so as to avoid potential interference from conflicting packages. This PR creates a dedicated container element for the sandbox app.