### PR TITLE
Make page container width compatible with JupyterLab

### DIFF
--- a/applications/jupyterlab-extension/src/jupyter/style.css
+++ b/applications/jupyterlab-extension/src/jupyter/style.css
@@ -4,4 +4,5 @@
 
 .lumy-flex > * {
   min-height: auto !important;
+  width: 100%;
 }

--- a/packages/client-ui/src/components/common/TopPageLayout.styles.ts
+++ b/packages/client-ui/src/components/common/TopPageLayout.styles.ts
@@ -4,7 +4,7 @@ import { Theme } from '@lumy/styles'
 export default makeStyles<Theme>(theme => ({
   pageContainer: {
     minHeight: '100vh',
-    width: '100vw',
+    width: '100%',
     overflow: 'hidden'
   },
   pageContent: {


### PR DESCRIPTION
Jupyter Lab adds its own frame around the extension app, which skews the proportions of the Lumy app.

<img width="921" alt="Screenshot 2022-01-07 at 15 29 10" src="https://user-images.githubusercontent.com/42968783/148560546-0c95c6cf-fece-4638-9429-9562afbad2d3.png">

This pull request will make the width adapt to being rendered inside JupyterLab while maintaining the desired aspect in the desktop app.